### PR TITLE
A command-line wrapper has been added to Galaxykit.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+## Version 0.1.0
+A command-line wrapper has been added to Galaxykit, enabling it to be used by non-Python
+code including Javascript UI tests.
+* namespace module was added to create test namespaces
+* Installing the galaxy-kit package now installs a galaxykit command in your PATH
+* HTTP request and response handling has been centralized in GalaxyClient
+* module functions now take the GalaxyClient object directly, instead of the root URL and headers
+
+## Version 0.0.1
+An initial prototype implementing basic functionality:
+* Creation, fetch, and delete of user accounts
+* Creation, deletion, and permission setting of groups
+* Utilities to push tagged containers into the services container registry
+* Authentication support

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -1,0 +1,100 @@
+import argparse
+import sys
+
+from .client import GalaxyClient
+from . import users
+from . import groups
+from . import namespaces
+
+
+def format_list(data, identifier):
+    buffer = []
+    for datum in data:
+        line = [datum[identifier]]
+        for key, value in datum.items():
+            if key != identifier and value:
+                s = f"{key}={value}"
+                line.append(s)
+        buffer.append(" ".join(line))
+    return "\n".join(buffer)
+
+
+def report_error(resp):
+    if "errors" in resp:
+        for error in resp["errors"]:
+            print(f"API Failure: HTTP {error['status']} {error['code']}; {error['title']} ({error['detail']})")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("kind", type=str, action="store",
+        help="Kind of API content to operate against (user, group, namespace)")
+    parser.add_argument("operation", type=str, action="store")
+    parser.add_argument("rest", type=str, action="store", nargs="*")
+    parser.add_argument("-u", "--username", type=str, action="store")
+    parser.add_argument("-p", "--password", type=str, action="store")
+    parser.add_argument("-s", "--server", type=str, action="store",
+        default="http://localhost:8002/api/automation-hub/")
+
+    args = parser.parse_args()
+
+    client = GalaxyClient(server, (args.username, args.password))
+
+    if args.kind == "user":
+        if args.operation == "list":
+            resp = users.get_user_list(client)
+            print(format_list(resp["data"], "username"))
+        if args.operation == "create":
+            username, password = args.rest
+            created, resp = users.get_or_create_user(client, username, password, None)
+            if created:
+                print("Created user", username)
+            else:
+                print(f"User {username} already existed")
+        if args.operation == "delete":
+            username, = args.rest
+            resp = users.delete_user(client.galaxy_root, client.headers, username)
+        if args.operation == "member":
+            subop, *subopargs = args.rest
+            if subop == "add":
+                username, groupname = subopargs
+                user_data = users.get_user(client, username)
+                group_id = groups.get_group_id(client, groupname)
+                user_data["groups"].append({
+                    "id": group_id,
+                    "name": groupname,
+                    "pulp_href": f"/pulp/api/v3/groups/{group_id}",
+                })
+                resp = users.update_user(client, user_data)
+
+    elif args.kind == "group":
+        if args.operation == "list":
+            resp = groups.get_group_list(client)
+            print(format_list(resp["data"], "name"))
+        if args.operation == "create":
+            name,  = args.rest
+            resp = groups.create_group(client, name)
+        if args.operation == "delete":
+            raise NotImplementedError
+
+    elif args.kind == "namespace":
+        if args.operation == "list":
+            raise NotImplementedError
+        if args.operation == "create":
+            print(args)
+            name, group = args.rest
+            resp = namespaces.create_namespace(client, name, group)
+        if args.operation == "delete":
+            raise NotImplementedError
+        if args.operation == "groups":
+            raise NotImplementedError
+        if args.operation == "addgroup":
+            raise NotImplementedError
+        if args.operation == "removegroup":
+            raise NotImplementedError
+        if args.operation == "addgroupperm":
+            raise NotImplementedError
+        if args.operation == "removegroupperm":
+            raise NotImplementedError
+    
+    report_error(resp)

--- a/galaxykit/dockerutils.py
+++ b/galaxykit/dockerutils.py
@@ -14,24 +14,24 @@ class DockerClient:
     engine = ""
     registry = ""
 
-    def __init__(self, auth_tuple=None, engine="podman", registry="docker.io/library/"):
+    def __init__(self, auth=None, engine="podman", registry="docker.io/library/"):
         """
-        auth_tuple should be `(username, password)` for logging into the docker registry.
+        auth should be `(username, password)` for logging into the docker registry.
 
         If not provided, then no login attempt is made.
         """
         self.engine = engine
         self.registry = registry
 
-        if auth_tuple:  # we only need to auth if creds are supplied
+        if auth:  # we only need to auth if creds are supplied
             run_args = [
                 engine,
                 "login",
                 registry,
                 "--username",
-                auth_tuple[0],
+                auth[0],
                 "--password",
-                auth_tuple[1],
+                auth[1],
             ]
             run(run_args)
 

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -1,0 +1,16 @@
+from . import groups
+
+def create_namespace(client, name, group):
+    group_id = groups.get_group_id(client, group)
+    create_body = {
+        "name": name,
+        "groups": [
+            {
+                "id": group_id,
+                "name": group,
+                "object_permissions": ["change_namespace", "upload_to_namespace"],
+            }
+        ],
+    }
+
+    return client.post("v3/namespaces/", create_body)

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,9 @@ setup(
     version="0.0.2",
     install_requires=["requests", "simplejson"],
     extra_requires={"dev": ["black", "pylint", "flake8"]},
+        entry_points={
+        'console_scripts': [
+            'galaxykit = galaxykit.command:main',
+        ],
+    },
 )


### PR DESCRIPTION
This enables it to be used by non-Python code including Javascript UI tests.
* namespace module was added to create test namespaces
* Installing the galaxy-kit package now installs a galaxykit command in
  your PATH
* HTTP request and response handling has been centralized in
  GalaxyClient
* module functions now take the GalaxyClient object directly, instead of
  the root URL and headers