### PR TITLE
[wip] Allow tls verify toggling for podman, simplify `docker tag` interface.

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -30,7 +30,12 @@ class GalaxyClient:
     docker_client = None
 
     def __init__(
-        self, galaxy_root, auth=None, container_engine=None, container_registry=None
+        self,
+        galaxy_root,
+        auth=None,
+        container_engine=None,
+        container_registry=None,
+        container_tls_verify=True,
     ):
         self.galaxy_root = galaxy_root
         self.headers = {}
@@ -53,11 +58,14 @@ class GalaxyClient:
             if container_engine:
                 container_registry = (
                     container_registry
-                    or urlparse(self.galaxy_root).netloc.split(":") + ":5001"
+                    or urlparse(self.galaxy_root).netloc.split(":")[0] + ":5001"
                 )
 
                 self.docker_client = dockerutils.DockerClient(
-                    (user, password), container_engine, container_registry
+                    (username, password),
+                    container_engine,
+                    container_registry,
+                    tls_verify=container_tls_verify,
                 )
 
     def _http(self, method, path, *args, **kwargs):
@@ -111,9 +119,9 @@ class GalaxyClient:
         """pulls an image with the given credentials"""
         return self.docker_client.pull_image(image_name)
 
-    def tag_image(self, image_name, newtag, version="latest"):
-        """tags a pulled image with the given newtag and version"""
-        return self.docker_client.tag_image(image_name, newtag, version=version)
+    def tag_image(self, image_name, newtag):
+        """tags a pulled image with the given newtag"""
+        return self.docker_client.tag_image(image_name, newtag)
 
     def push_image(self, image_tag):
         """pushs a image"""

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -1,16 +1,17 @@
 """
 client.py contains the wrapping interface for all the other modules (aside from cli.py)
 """
-from simplejson.errors import JSONDecodeError
-from simplejson import dumps
 import sys
 from urllib.parse import urlparse, urljoin
+from simplejson.errors import JSONDecodeError
+from simplejson import dumps
 
 import requests
 
+from . import containers
 from . import dockerutils
-from . import users
 from . import groups
+from . import users
 
 
 class GalaxyClientError(Exception):
@@ -40,7 +41,7 @@ class GalaxyClient:
             resp = requests.post(auth_url, auth=(username, password))
             try:
                 self.token = resp.json().get("token")
-            except JSONDecodeError as e:
+            except JSONDecodeError:
                 print(f"Failed to fetch token: {resp.text}", file=sys.stderr)
             self.headers.update(
                 {
@@ -68,9 +69,11 @@ class GalaxyClient:
         if parse_json:
             try:
                 json = resp.json()
-            except JSONDecodeError as e:
+            except JSONDecodeError:
                 print(resp.text)
-                raise ValueError("Failed to parse JSON response from API")
+                raise ValueError(
+                    "Failed to parse JSON response from API"
+                ) from JSONDecodeError
             if "errors" in json:
                 # {'errors': [{'status': '403', 'code': 'not_authenticated', 'title': 'Authentication credentials were not provided.'}]}
                 raise GalaxyClientError(*json["errors"])
@@ -135,6 +138,7 @@ class GalaxyClient:
         )
 
     def get_user_list(self):
+        """returns a list of all the users"""
         return users.get_user_list(self)
 
     def delete_user(self, username):

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -1,9 +1,15 @@
 def get_readme(client, container):
+    """
+    Returns a json response containing the readme
+    """
     url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
     return client.get(url)
 
 
 def set_readme(client, container, readme):
+    """
+    Accepts a string and sets the container readme to that string.
+    """
     url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
     resp = get_readme(client, container)
     resp["text"] = readme

--- a/galaxykit/dockerutils.py
+++ b/galaxykit/dockerutils.py
@@ -13,8 +13,11 @@ class DockerClient:
 
     engine = ""
     registry = ""
+    tls_verify = True
 
-    def __init__(self, auth=None, engine="podman", registry="docker.io/library/"):
+    def __init__(
+        self, auth=None, engine="podman", registry="docker.io/library/", tls_verify=True
+    ):
         """
         auth should be `(username, password)` for logging into the docker registry.
 
@@ -22,33 +25,68 @@ class DockerClient:
         """
         self.engine = engine
         self.registry = registry
+        self.tls_verify = tls_verify
 
         if auth:  # we only need to auth if creds are supplied
-            run_args = [
-                engine,
-                "login",
-                registry,
-                "--username",
-                auth[0],
-                "--password",
-                auth[1],
-            ]
+            if engine == "podman":
+                run_args = [
+                    engine,
+                    "login",
+                    registry,
+                    "--username",
+                    auth[0],
+                    "--password",
+                    auth[1],
+                    f"--tls-verify={tls_verify}"  # this is only valid/necessary
+                    # with podman
+                ]
+            else:
+                run_args = [
+                    engine,
+                    "login",
+                    registry,
+                    "--username",
+                    auth[0],
+                    "--password",
+                    auth[1],
+                ]
             run(run_args)
 
     def pull_image(self, image_name):
         """
         pull an image from the configured default registry
         """
-        run([self.engine, "pull", self.registry + image_name])
+        if self.engine == "podman" and not self.tls_verify:
+            run([self.engine, "pull", self.registry + image_name, "--tls-verify=False"])
+        else:
+            run([self.engine, "pull", self.registry + image_name])
 
-    def tag_image(self, image_name, newtag, version="latest"):
+    def tag_image(self, image_name, newtag):
         """
-        Tags an image with the given tag
+        Tags an image with the given tag (prepends the registry to the tag.)
         """
-        run([self.engine, "image", "tag", image_name, f"{newtag}:{version}"])
+        run(
+            [
+                self.engine,
+                "image",
+                "tag",
+                image_name,
+                f"{self.registry}/{newtag}",
+            ]
+        )
 
     def push_image(self, image_tag):
         """
-        Pushes an image
+        Pushes an image to the registry
         """
-        run([self.engine, "push", image_tag])
+        if self.engine == "podman" and not self.tls_verify:
+            run(
+                [
+                    self.engine,
+                    "push",
+                    f"{self.registry}/{image_tag}",
+                    "--tls-verify=False",
+                ]
+            )
+        else:
+            run([self.engine, "push", f"{self.registry}/{image_tag}"])

--- a/galaxykit/dockerutils.py
+++ b/galaxykit/dockerutils.py
@@ -28,28 +28,17 @@ class DockerClient:
         self.tls_verify = tls_verify
 
         if auth:  # we only need to auth if creds are supplied
+            run_args = [
+                engine,
+                "login",
+                registry,
+                "--username",
+                auth[0],
+                "--password",
+                auth[1],
+            ]
             if engine == "podman":
-                run_args = [
-                    engine,
-                    "login",
-                    registry,
-                    "--username",
-                    auth[0],
-                    "--password",
-                    auth[1],
-                    f"--tls-verify={tls_verify}"  # this is only valid/necessary
-                    # with podman
-                ]
-            else:
-                run_args = [
-                    engine,
-                    "login",
-                    registry,
-                    "--username",
-                    auth[0],
-                    "--password",
-                    auth[1],
-                ]
+                run_args.append(f"--tls-verify={tls_verify}")
             run(run_args)
 
     def pull_image(self, image_name):
@@ -79,14 +68,13 @@ class DockerClient:
         """
         Pushes an image to the registry
         """
+        run_args = [
+            self.engine,
+            "push",
+            f"{self.registry}/{image_tag}",
+        ]
+
         if self.engine == "podman" and not self.tls_verify:
-            run(
-                [
-                    self.engine,
-                    "push",
-                    f"{self.registry}/{image_tag}",
-                    "--tls-verify=False",
-                ]
-            )
-        else:
-            run([self.engine, "push", f"{self.registry}/{image_tag}"])
+            run_args.append(f"--tls-verify={self.tls_verify}")
+
+        run(run_args)

--- a/galaxykit/dockerutils.py
+++ b/galaxykit/dockerutils.py
@@ -74,7 +74,7 @@ class DockerClient:
             f"{self.registry}/{image_tag}",
         ]
 
-        if self.engine == "podman" and not self.tls_verify:
+        if self.engine == "podman":
             run_args.append(f"--tls-verify={self.tls_verify}")
 
         run(run_args)


### PR DESCRIPTION
Note: We'll need to merge in #10 before merging in this.

## Reasoning:

Because many of the installations of galaxy_ng we use for testing will
use self-signed certs, if we want to use podman in our tests we need to
make it possible to turn off tls-verify. This is possible on the command-line with `--tls-verify=false`.  These changes add a `tls_verify` argument that toggles that option in the `dockerutils` module.

In addition this commit simplifies the interface for the  `docker tag`
argument - now rather than requiring an explicit `version` argument, the
caller of the function should simply put the version in the tag that
they applying to the image.